### PR TITLE
Add rancher nodes to atlas firewall

### DIFF
--- a/api/v1alpha1/mongodbcluster_types.go
+++ b/api/v1alpha1/mongodbcluster_types.go
@@ -50,7 +50,7 @@ type MongoDBClusterSpec struct {
 	UseAtlasApi bool `json:"useAtlasApi,omitempty"`
 
 	// If this is set, along with useAtlasApi, all the kubernetes nodes on the cluster will be added to the Atlas firewall. The only available value right now is "rancher-annotation", which uses the rke.cattle.io/external-ip annotation.
-	AtlasNodeIPAccessStrategy string `json:"atlasNodeIPAccessStrategy,omitempty"`
+	AtlasNodeIPAccessStrategy string `json:"atlasNodeIpAccessStrategy,omitempty"`
 }
 
 // MongoDBClusterStatus defines the observed state of MongoDBCluster

--- a/api/v1alpha1/mongodbcluster_types.go
+++ b/api/v1alpha1/mongodbcluster_types.go
@@ -48,6 +48,9 @@ type MongoDBClusterSpec struct {
 
 	// If this is set, Atlas API will be used instead of the regular mongo auth path.
 	UseAtlasApi bool `json:"useAtlasApi,omitempty"`
+
+	// If this is set, along with useAtlasApi, all the kubernetes nodes on the cluster will be added to the Atlas firewall, using the rke.cattle.io/external-ip annotation.
+	AllowOnAtlasFirewall bool `json:"allowOnAtlasFirewall,omitempty"`
 }
 
 // MongoDBClusterStatus defines the observed state of MongoDBCluster

--- a/api/v1alpha1/mongodbcluster_types.go
+++ b/api/v1alpha1/mongodbcluster_types.go
@@ -49,8 +49,8 @@ type MongoDBClusterSpec struct {
 	// If this is set, Atlas API will be used instead of the regular mongo auth path.
 	UseAtlasApi bool `json:"useAtlasApi,omitempty"`
 
-	// If this is set, along with useAtlasApi, all the kubernetes nodes on the cluster will be added to the Atlas firewall, using the rke.cattle.io/external-ip annotation.
-	AllowOnAtlasFirewall bool `json:"allowOnAtlasFirewall,omitempty"`
+	// If this is set, along with useAtlasApi, all the kubernetes nodes on the cluster will be added to the Atlas firewall. The only available value right now is "rancher-annotation", which uses the rke.cattle.io/external-ip annotation.
+	AtlasNodeIPAccessStrategy string `json:"atlasNodeIPAccessStrategy,omitempty"`
 }
 
 // MongoDBClusterStatus defines the observed state of MongoDBCluster

--- a/api/v1alpha1/mongodbcluster_types.go
+++ b/api/v1alpha1/mongodbcluster_types.go
@@ -43,7 +43,7 @@ type MongoDBClusterSpec struct {
 	// +kubebuilder:default=mongodb
 	PrefixTemplate string `json:"prefixTemplate,omitempty"`
 
-	// Append this prefix to all default/generated usernames for this cluster. Will be overriden if "username" is specified.
+	// Append this prefix to all default/generated usernames for this cluster. Will be overridden if "username" is specified.
 	UserNamePrefix string `json:"userNamePrefix,omitempty"`
 
 	// If this is set, Atlas API will be used instead of the regular mongo auth path.

--- a/config/crd/bases/airlock.cloud.rocket.chat_mongodbclusters.yaml
+++ b/config/crd/bases/airlock.cloud.rocket.chat_mongodbclusters.yaml
@@ -41,11 +41,12 @@ spec:
             type: object
           spec:
             properties:
-              allowOnAtlasFirewall:
-                description: If this is set, all the kubernetes nodes on the cluster
-                  will be added to the Atlas firewall, using rke.cattle.io/external-ip
-                  annotation.
-                type: boolean
+              atlasNodeIPAccessStrategy:
+                description: If this is set, along with useAtlasApi, all the kubernetes
+                  nodes on the cluster will be added to the Atlas firewall. The only
+                  available value right now is "rancher-annotation", which uses the
+                  rke.cattle.io/external-ip annotation.
+                type: string
               connectionSecret:
                 description: Secret in which Airlock will look for a ConnectionString
                   or Atlas credentials, that will be used to connect to the cluster.
@@ -75,7 +76,7 @@ spec:
                 type: boolean
               userNamePrefix:
                 description: Append this prefix to all default/generated usernames
-                  for this cluster. Will be overriden if "username" is specified.
+                  for this cluster. Will be overridden if "username" is specified.
                 type: string
             required:
             - connectionSecret

--- a/config/crd/bases/airlock.cloud.rocket.chat_mongodbclusters.yaml
+++ b/config/crd/bases/airlock.cloud.rocket.chat_mongodbclusters.yaml
@@ -41,7 +41,7 @@ spec:
             type: object
           spec:
             properties:
-              atlasNodeIPAccessStrategy:
+              atlasNodeIpAccessStrategy:
                 description: If this is set, along with useAtlasApi, all the kubernetes
                   nodes on the cluster will be added to the Atlas firewall. The only
                   available value right now is "rancher-annotation", which uses the

--- a/config/crd/bases/airlock.cloud.rocket.chat_mongodbclusters.yaml
+++ b/config/crd/bases/airlock.cloud.rocket.chat_mongodbclusters.yaml
@@ -41,6 +41,11 @@ spec:
             type: object
           spec:
             properties:
+              allowOnAtlasFirewall:
+                description: If this is set, all the kubernetes nodes on the cluster
+                  will be added to the Atlas firewall, using rke.cattle.io/external-ip
+                  annotation.
+                type: boolean
               connectionSecret:
                 description: Secret in which Airlock will look for a ConnectionString
                   or Atlas credentials, that will be used to connect to the cluster.

--- a/config/samples/airlock_v1alpha1_mongodbcluster.yaml
+++ b/config/samples/airlock_v1alpha1_mongodbcluster.yaml
@@ -35,8 +35,8 @@ spec:
   # Optional. Append this prefix to all default/generated usernames for this cluster. Will be ignored if "username" is already set on the access request.
   userNamePrefix: test-use1-
 
-  # Optional. If this is set, along with useAtlasApi, all the kubernetes nodes on the cluster will be added to the Atlas firewall, using the rke.cattle.io/external-ip annotation.
-  allowOnAtlasFirewall: true
+  # Optional. If this is set, along with useAtlasApi, all the kubernetes nodes on the cluster will be added to the Atlas firewall. The only available value right now is "rancher-annotation", which uses the rke.cattle.io/external-ip annotation.
+  atlasNodeIPAccessStrategy: rancher-annotation
 
 ---
 apiVersion: v1

--- a/config/samples/airlock_v1alpha1_mongodbcluster.yaml
+++ b/config/samples/airlock_v1alpha1_mongodbcluster.yaml
@@ -35,6 +35,9 @@ spec:
   # Optional. Append this prefix to all default/generated usernames for this cluster. Will be ignored if "username" is already set on the access request.
   userNamePrefix: test-use1-
 
+  # Optional. If this is set, along with useAtlasApi, all the kubernetes nodes on the cluster will be added to the Atlas firewall, using the rke.cattle.io/external-ip annotation.
+  allowOnAtlasFirewall: true
+
 ---
 apiVersion: v1
 kind: Secret

--- a/config/samples/airlock_v1alpha1_mongodbcluster.yaml
+++ b/config/samples/airlock_v1alpha1_mongodbcluster.yaml
@@ -36,7 +36,7 @@ spec:
   userNamePrefix: test-use1-
 
   # Optional. If this is set, along with useAtlasApi, all the kubernetes nodes on the cluster will be added to the Atlas firewall. The only available value right now is "rancher-annotation", which uses the rke.cattle.io/external-ip annotation.
-  atlasNodeIPAccessStrategy: rancher-annotation
+  atlasNodeIpAccessStrategy: rancher-annotation
 
 ---
 apiVersion: v1

--- a/controllers/mongodbcluster_controller.go
+++ b/controllers/mongodbcluster_controller.go
@@ -125,7 +125,7 @@ func (r *MongoDBClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 
 		// Add nodes to Atlas firewall
-		if mongodbClusterCR.Spec.AllowOnAtlasFirewall {
+		if mongodbClusterCR.Spec.AtlasNodeIPAccessStrategy == "rancher-annotation" {
 			err = r.reconcileAtlasFirewall(ctx, mongodbClusterCR, secret)
 			if err != nil {
 				meta.SetStatusCondition(&mongodbClusterCR.Status.Conditions,
@@ -231,7 +231,7 @@ func (r *MongoDBClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 				requests := make([]reconcile.Request, 0)
 				for _, item := range mongodbClusterCR.Items {
-					if item.Spec.AllowOnAtlasFirewall {
+					if item.Spec.AtlasNodeIPAccessStrategy != "" {
 						requests = append(requests, reconcile.Request{
 							NamespacedName: types.NamespacedName{
 								Name:      item.GetName(),


### PR DESCRIPTION
This PR adds the option to reconcile the atlas firewall/IP access list, so that each node in the cluster can access it. In the current implementation, only Rancher is supported.