### PR TITLE
chore: pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,13 +21,13 @@ jobs:
       matrix:
         platform: [linux/amd64, linux/arm64]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 1
           path: ${{ env.__W_SRC_REL }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: ${{ env.__W_SRC_REL }}/go.mod
 
@@ -40,11 +40,11 @@ jobs:
 
       - name: Set up QEMU
         if: ${{ matrix.platform == 'linux/arm64' }}
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
         if: ${{ matrix.platform == 'linux/arm64' }}
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Tag arch images
         id: tag
@@ -53,13 +53,13 @@ jobs:
           echo "tag=${platform##*/}" >> $GITHUB_OUTPUT
 
       - name: Login to Docker Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           username: ${{ secrets.DOCKERREGISTRY_USERNAME }}
           password: ${{ secrets.DOCKERREGISTRY_PASSWORD }}
 
       - name: Docker build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3.3.1
         with:
           context: ${{ env.__W_SRC_REL }}
           file: ${{ env.__W_SRC_REL }}/Dockerfile
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to Docker Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           username: ${{ secrets.DOCKERREGISTRY_USERNAME }}
           password: ${{ secrets.DOCKERREGISTRY_PASSWORD }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,16 +16,16 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3.6.1
         with:
           go-version: 1.21
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Configure git for private modules
         env:
           PRIVATE_REPO_ACCESS_KEY: ${{ secrets.PRIVATE_REPO_ACCESS_KEY }}
         run: git config --global url."https://rocketchat-cloudbot:$PRIVATE_REPO_ACCESS_KEY@github.com".insteadOf "https://github.com"
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           version: v1.62
           skip-build-cache: true

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
 
       - name: Checkout cloud ops
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: ${{ env.CLOUD_OPS_REPO }}
           token: ${{ secrets.CI_CLOUD_OPS_PERSONAL_ACCESS_TOKEN }}
@@ -40,7 +40,7 @@ jobs:
           echo "NEW_TAG=$GITHUB_SHA" >> $GITHUB_ENV
 
       - name: Checkout source repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: ${{ env.SOURCE_REPO }}
           path: source-repo


### PR DESCRIPTION
# Proposed changes
This PR replaces mutable tag references with immutable commit SHA pins for all third-party GitHub Actions, as part of a supply chain security hardening effort.

Each workflow file now references the exact commit SHA of the desired action version instead of a floating tag. This guarantees that the same code is always executed regardless of whether the version tag is moved or the action's repository is modified after pinning.

# Issue(s)
[SB-958](https://rocketchat.atlassian.net/browse/SB-958)

[SB-958]: https://rocketchat.atlassian.net/browse/SB-958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ