### PR TITLE
chore: apply least privilege permissions to github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,15 +8,15 @@ on:
       - main
   pull_request:
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 env:
   __W_SRC_REL: go/src/github.com/RocketChat/airlock
 jobs:
   build:
     name: Build and test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         platform: [linux/amd64, linux/arm64]
@@ -72,6 +72,7 @@ jobs:
     needs: [build]
     name: Join platform tags
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Login to Docker Registry
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,13 +8,14 @@ on:
       - master
       - main
   pull_request:
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3.6.1
         with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -7,9 +7,13 @@ on:
       - main
       - develop
 
+permissions: {}
+
 jobs:
   promote:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       CLOUD_OPS_REPO: RocketChat/cloud-ops
       IMAGE_NAME: airlock


### PR DESCRIPTION
## Proposed changes
This PR applies the principle of least privilege to `GITHUB_TOKEN` permissions across all GitHub Actions workflows by setting `permissions: {}` globally and explicitly re-granting only the minimum permissions required per job, as part of a supply chain security hardening effort.

Workflows relied on GitHub’s default token scopes, which may grant more access than most jobs actually need. Scoping permissions at the job level reduces the attack surface in the event that a GitHub Action, third-party dependency, or CI component is compromised, helping mitigate the impact of potential supply chain attacks and limiting unnecessary repository access.

This change only affects the permissions granted to the workflow `GITHUB_TOKEN`. Operations authenticated using explicitly configured Personal Access Tokens (PATs) continue to have the scopes assigned to those tokens and are not affected by workflow permissions settings.

## Issue(s)
[SB-975](https://rocketchat.atlassian.net/browse/SB-975)

[SB-975]: https://rocketchat.atlassian.net/browse/SB-975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ